### PR TITLE
Fix config constants and blog post description

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@
 export const SITE_TITLE = 'Wayne Graham';
 export const SITE_DESCRIPTION =
     "Explore my professional profile as a seasoned IT leader with expertise in informatics, cultural networks, and knowledge systems. Learn about my work, projects, and experiences";
-export const GENERATE_SLUG_FROM_TITLE = true
+export const GENERATE_SLUG_FROM_TITLE = true;
 
-export const TRANSITION_API = true
+export const TRANSITION_API = true;
+

--- a/src/content/blog/coffee-butler.md
+++ b/src/content/blog/coffee-butler.md
@@ -1,6 +1,6 @@
 ---
 title: "Coffee Roasting AI App"
-description: "Experiements in developing "
+description: "Experiments in developing an AI-powered roasting journal"
 pubDate: "October 12 2024"
 heroImage: "https://images.unsplash.com/photo-1511537190424-bbbab87ac5eb?q=80&w=2370&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
 ---
@@ -12,4 +12,5 @@ I looked in to some apps that I could run on my phone to store this information 
 I started playing around with Swift in order to figure out some UI elements as this is effectively a journaling app. I dove in to SwiftUI and got some working components, but wanted to add support for adding weather. This is where I ran into an issue as getting access to the WeatherKit framework required me to purchase an Apple Developer license and I just wasn't willing to shell out the $99 to _maybe_ develop an app that I expect to make $0 on. 
 
 I have a lot more experience developing in web frameworks, and I've been interested in React for a while. I've also been reading about AI-driven development and wanted to give these tools a shot.
+
 


### PR DESCRIPTION
## Summary
- fix missing semicolon in `TRANSITION_API` constant
- correct typo in Coffee Butler blog post description

## Testing
- `pnpm test` *(fails: ERR_PNPM_NO_SCRIPT)*

------
https://chatgpt.com/codex/tasks/task_e_6842dcfdedac832d87ffdef9c4fbd768